### PR TITLE
Add support for running `lustre/dev build` in path dependencies with `lustre_dev_tools` dev-dependency

### DIFF
--- a/src/olive.gleam
+++ b/src/olive.gleam
@@ -89,7 +89,7 @@ fn listen_to_file_changes(
           logging.debug(config.logger, "Files changed:\n" <> changelog)
 
           let after_build = case needs_rebuild(changes) {
-            True -> server_run.reload_server_code(config)
+            True -> server_run.reload_server_code(config, changes)
             False -> Ok(Nil)
           }
 

--- a/src/olive.gleam
+++ b/src/olive.gleam
@@ -89,7 +89,14 @@ fn listen_to_file_changes(
           logging.debug(config.logger, "Files changed:\n" <> changelog)
 
           let after_build = case needs_rebuild(changes) {
-            True -> server_run.reload_server_code(config, changes)
+            True ->
+              server_run.reload_server_code(
+                config,
+                changes
+                  |> list.map(fn(change) { change.dir })
+                  |> list.unique,
+              )
+
             False -> Ok(Nil)
           }
 
@@ -118,8 +125,8 @@ fn needs_rebuild(changes: List(watcher.Change)) {
   changes
   |> list.any(fn(change) {
     case change {
-      watcher.SourceChange(..) -> True
-      watcher.PrivChange(..) -> False
+      watcher.Change(dir: config.SourceDirectory(..), ..) -> True
+      watcher.Change(dir: config.PrivDirectory(..), ..) -> False
     }
   })
 }

--- a/src/olive/config.gleam
+++ b/src/olive/config.gleam
@@ -164,7 +164,7 @@ fn get_gleam_toml_path() -> Result(String, String) {
   |> result.then(get_root)
 }
 
-fn get_root(path: String) -> Result(String, String) {
+pub fn get_root(path: String) -> Result(String, String) {
   case simplifile.is_file(filepath.join(path, "gleam.toml")) {
     Ok(True) -> Ok(path)
     Ok(False) | Error(_) -> {

--- a/src/olive/config.gleam
+++ b/src/olive/config.gleam
@@ -11,7 +11,7 @@ import simplifile
 import tom
 
 pub type Directory {
-  SourceDirectory(path: String)
+  SourceDirectory(path: String, uses_lustre_dev_tools: Bool)
   PrivDirectory(path: String)
 }
 
@@ -82,7 +82,7 @@ fn read_project_dependencies(toml: TomlFile, root: String) {
   // We want path dependencies only.
   // Path dependencies such as `common = { path = "../common" }` will be
   // watched at "../common/src" as well as the main src folder.
-  let source_directory = check_source_directory(root)
+  let source_directory = check_source_directory(root, False)
   let priv_directory = check_priv_directory(root)
 
   tom.get_table(toml, ["dependencies"])
@@ -98,9 +98,15 @@ fn read_project_dependencies(toml: TomlFile, root: String) {
               Error(_) -> acc
               Ok(tom.String(path)) -> {
                 let full_path = filepath.join(root, path)
-                let source_dir = check_source_directory(full_path)
-                let priv_dir = check_priv_directory(full_path)
-                [source_dir, priv_dir, ..acc]
+                let uses_lustre_dev_tools = uses_lustre_dev_tools(full_path)
+                [
+                  check_source_directory(full_path, uses_lustre_dev_tools),
+                  case uses_lustre_dev_tools {
+                    True -> option.None
+                    False -> check_priv_directory(full_path)
+                  },
+                  ..acc
+                ]
               }
               Ok(_) -> acc
             }
@@ -113,8 +119,27 @@ fn read_project_dependencies(toml: TomlFile, root: String) {
   })
 }
 
-fn check_source_directory(root: String) {
-  check_directory(filepath.join(root, "src"), SourceDirectory)
+fn uses_lustre_dev_tools(root: String) {
+  let result = {
+    use gleam_toml <- result.try(read_gleam_toml(root))
+
+    tom.get_table(gleam_toml, ["dev-dependencies"])
+    |> result.map_error(tom_field_error_to_string)
+    |> result.map(fn(dev_deps) {
+      dev_deps
+      |> dict.keys
+      |> list.contains("lustre_dev_tools")
+    })
+  }
+
+  result.unwrap(result, False)
+}
+
+fn check_source_directory(root: String, uses_lustre_dev_tools: Bool) {
+  check_directory(filepath.join(root, "src"), SourceDirectory(
+    path: _,
+    uses_lustre_dev_tools:,
+  ))
 }
 
 fn check_priv_directory(root: String) {
@@ -166,7 +191,7 @@ fn print_deps(deps: List(Directory)) {
     list.map(deps, fn(dir) {
       case dir {
         PrivDirectory(path) -> "Any changes in: " <> path
-        SourceDirectory(path) -> "Code changes in: " <> path
+        SourceDirectory(path, ..) -> "Code changes in: " <> path
       }
     }),
     "\n",

--- a/src/olive/server_run.gleam
+++ b/src/olive/server_run.gleam
@@ -1,11 +1,16 @@
 //// the `server_run` module runs the "main" server and also handles the rebuilding
 //// of the main server code every time it is needed.
 
+import filepath
 import gleam/erlang/atom
 import gleam/erlang/process
+import gleam/list
+import gleam/option
 import gleam/result
+import gleam/string
 import olive/config
 import olive/logging
+import olive/watcher
 import shellout
 
 // From gleam-radiate
@@ -24,24 +29,70 @@ fn spawn_main_server(
 ) -> Result(process.Pid, atom.Atom)
 
 pub fn start_server(config: config.Config) {
-  use _ <- result.try(build_server(config))
+  use _ <- result.try(build_server(config, []))
   use fully_qualified_module <- result.try(get_atom(config.name <> "@@main"))
   use module <- result.try(get_atom(config.name))
   spawn_main_server(config.root, fully_qualified_module, module)
   |> result.map_error(posix_error_to_string(config, _))
 }
 
-pub fn reload_server_code(config: config.Config) {
-  build_server(config)
+pub fn reload_server_code(config: config.Config, changes: List(watcher.Change)) {
+  build_server(config, changes)
   |> result.try(fn(_output) {
     reload_modules()
     |> result.map_error(fn(_) { "Error while reloading Erlang modules" })
   })
 }
 
-fn build_server(config: config.Config) {
-  logging.notice(config.logger, "Launching new build via `gleam build`")
-  shellout.command(run: "gleam", with: ["build"], in: config.root, opt: [
+fn build_server(config: config.Config, changes: List(watcher.Change)) {
+  changes
+  |> list.map(fn(change) {
+    case change {
+      watcher.SourceChange(dir_path:, uses_lustre_dev_tools: True, ..) ->
+        option.Some(dir_path)
+
+      _ -> option.None
+    }
+  })
+  |> option.values
+  |> list.unique
+  |> list.each(fn(dir_path) {
+    let assert Ok(root) =
+      dir_path
+      |> filepath.join("..")
+      |> filepath.expand
+
+    let after_build =
+      run_build(config, with: ["run", "-m", "lustre/dev", "build"], in: root)
+
+    case after_build {
+      Ok(_) -> Nil
+      Error(msg) -> logging.error(config.logger, msg)
+    }
+  })
+
+  run_build(config, with: ["build"], in: config.root)
+}
+
+fn run_build(
+  config: config.Config,
+  with arguments: List(String),
+  in directory: String,
+) {
+  let executable = "gleam"
+
+  logging.notice(
+    config.logger,
+    "Launching new build via `"
+      <> executable
+      <> " "
+      <> string.join(arguments, " ")
+      <> "` in `"
+      <> directory
+      <> "`",
+  )
+
+  shellout.command(run: executable, with: arguments, in: directory, opt: [
     shellout.LetBeStderr,
     shellout.LetBeStdout,
   ])

--- a/src/olive/server_run.gleam
+++ b/src/olive/server_run.gleam
@@ -1,16 +1,13 @@
 //// the `server_run` module runs the "main" server and also handles the rebuilding
 //// of the main server code every time it is needed.
 
-import filepath
 import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/list
-import gleam/option
 import gleam/result
 import gleam/string
 import olive/config
 import olive/logging
-import olive/watcher
 import shellout
 
 // From gleam-radiate
@@ -29,43 +26,39 @@ fn spawn_main_server(
 ) -> Result(process.Pid, atom.Atom)
 
 pub fn start_server(config: config.Config) {
-  use _ <- result.try(build_server(config, []))
+  use _ <- result.try(build_server(config, config.dirs))
   use fully_qualified_module <- result.try(get_atom(config.name <> "@@main"))
   use module <- result.try(get_atom(config.name))
   spawn_main_server(config.root, fully_qualified_module, module)
   |> result.map_error(posix_error_to_string(config, _))
 }
 
-pub fn reload_server_code(config: config.Config, changes: List(watcher.Change)) {
-  build_server(config, changes)
+pub fn reload_server_code(
+  config: config.Config,
+  changed_dirs: List(config.Directory),
+) {
+  build_server(config, changed_dirs)
   |> result.try(fn(_output) {
     reload_modules()
     |> result.map_error(fn(_) { "Error while reloading Erlang modules" })
   })
 }
 
-fn build_server(config: config.Config, changes: List(watcher.Change)) {
-  changes
-  |> list.map(fn(change) {
-    case change {
-      watcher.SourceChange(dir_path:, uses_lustre_dev_tools: True, ..) ->
-        option.Some(dir_path)
-
-      _ -> option.None
+fn build_server(config: config.Config, changed_dirs: List(config.Directory)) {
+  changed_dirs
+  |> list.filter_map(fn(changed_dir) {
+    case changed_dir {
+      config.SourceDirectory(path:, uses_lustre_dev_tools: True) -> Ok(path)
+      _ -> Error(Nil)
     }
   })
-  |> option.values
-  |> list.unique
-  |> list.each(fn(dir_path) {
-    let assert Ok(root) =
-      dir_path
-      |> filepath.join("..")
-      |> filepath.expand
-
-    let after_build =
+  |> list.each(fn(changed_src_path) {
+    let result = {
+      use root <- result.try(config.get_root(changed_src_path))
       run_build(config, with: ["run", "-m", "lustre/dev", "build"], in: root)
+    }
 
-    case after_build {
+    case result {
       Ok(_) -> Nil
       Error(msg) -> logging.error(config.logger, msg)
     }

--- a/src/olive/watcher.gleam
+++ b/src/olive/watcher.gleam
@@ -31,8 +31,7 @@ fn fs_subscribe(name: Atom) -> Atom
 fn check_watcher_installed() -> Result(Nil, WatcherError)
 
 pub type Change {
-  SourceChange(file_name: String, dir_path: String, uses_lustre_dev_tools: Bool)
-  PrivChange(file_name: String)
+  Change(file_name: String, dir: config.Directory)
 }
 
 pub type Message {
@@ -118,11 +117,7 @@ fn do_loop(msg: InternalMsg, state: State) {
       // Watcher sends multiple events for a same save,
       // so we debounce it to avoid multiple builds in a very short time
       // we also avoid adding it again to the current debounced changes
-      let new_change = case dir {
-        config.SourceDirectory(path:, uses_lustre_dev_tools:) ->
-          SourceChange(file_name, dir_path: path, uses_lustre_dev_tools:)
-        config.PrivDirectory(_) -> PrivChange(file_name)
-      }
+      let new_change = Change(file_name:, dir:)
       let current_changes = set.insert(state.current_changes, new_change)
       let timer =
         process.send_after(


### PR DESCRIPTION
This PR enhances the build system to support path dependencies that use `lustre_dev_tools` as a dev-dependency.

### Changes

- When a path dependency declares `lustre_dev_tools` as a dev-dependency, the build system now executes `gleam run -m lustre/dev build` in that dependency's directory whenever source files change.

- Ensures seamless integration for projects with a separate frontend relying on `lustre_dev_tools`.

### Motivation

This change improves the developer experience by automatically triggering the `lustre/dev build` command for path dependencies that use `lustre_dev_tools`. It eliminates the need for manual intervention in projects with a separate frontend, streamlining the development workflow.