### PR TITLE
Add page reload on WebSocket reconnect to prevent stale views

### DIFF
--- a/priv/proxy.js
+++ b/priv/proxy.js
@@ -1,12 +1,20 @@
 let liveReloadWebSocket = null;
 let reconnectTimeout = null;
 
+const RELOAD_ON_RECONNECT_KEY = "shouldReload";
+
 function connect() {
   clearTimeout(reconnectTimeout);
   liveReloadWebSocket = new WebSocket(
     `ws://${window.location.host}/ws_livereload`,
   );
 
+  liveReloadWebSocket.onopen = () => {
+    if (sessionStorage.getItem(RELOAD_ON_RECONNECT_KEY)) {
+      sessionStorage.removeItem(RELOAD_ON_RECONNECT_KEY);
+      window.location.reload();
+    }
+  };
   liveReloadWebSocket.onmessage = (event) => {
     window.location.reload();
   };
@@ -15,6 +23,7 @@ function connect() {
 }
 
 function reconnect() {
+  sessionStorage.setItem(RELOAD_ON_RECONNECT_KEY, "true");
   clearTimeout(reconnectTimeout);
   reconnectTimeout = setTimeout(connect, 5000);
 }


### PR DESCRIPTION
Triggers a full page reload when the WebSocket reconnects (e.g., after a dev server restart) to avoid a stale page.